### PR TITLE
amdgpu: reintroduce green_sardine and sienna_cichlid firmware

### DIFF
--- a/amdgpukmsfw/Makefile
+++ b/amdgpukmsfw/Makefile
@@ -23,6 +23,7 @@ _VALID_AMDGPUKMODS=	banks \
 			raven2 \
 			renoir \
 			si58 \
+			sienna_cichlid \
 			stoney \
 			tahiti \
 			tonga \
@@ -514,6 +515,21 @@ SUBDIR+=	navi14_asd	\
 		navi14_vcn
 .endif
 
+
+.if ${AMDGPUKMODS:Msienna_cichlid}
+SUBDIR+=	sienna_cichlid_ce	\
+		sienna_cichlid_dmcub	\
+		sienna_cichlid_me	\
+		sienna_cichlid_mec	\
+		sienna_cichlid_mec2	\
+		sienna_cichlid_pfp	\
+		sienna_cichlid_rlc	\
+		sienna_cichlid_sdma	\
+		sienna_cichlid_smc	\
+		sienna_cichlid_sos	\
+		sienna_cichlid_ta	\
+		sienna_cichlid_vcn
+.endif
 SUBDIR_PARALLEL=
 
 .include <bsd.subdir.mk>

--- a/amdgpukmsfw/Makefile
+++ b/amdgpukmsfw/Makefile
@@ -4,6 +4,7 @@ _VALID_AMDGPUKMODS=	banks \
 			bonaire \
 			carrizo \
 			fiji \
+			green_sardine \
 			hainan \
 			hawaii \
 			kabini \
@@ -329,6 +330,20 @@ SUBDIR+=	vegam_ce	\
 .endif
 
 ## GFX9/GCN
+.if ${AMDGPUKMODS:Mgreen_sardine}
+SUBDIR+=	green_sardine_asd	\
+		green_sardine_ce	\
+		green_sardine_dmcub	\
+		green_sardine_me	\
+		green_sardine_mec	\
+		green_sardine_mec2	\
+		green_sardine_pfp	\
+		green_sardine_rlc	\
+		green_sardine_sdma	\
+		green_sardine_ta	\
+		green_sardine_vcn
+.endif
+
 .if ${AMDGPUKMODS:Mpicasso}
 SUBDIR+=	picasso_asd		\
 		picasso_ce		\


### PR DESCRIPTION
This PR addresses #21 
Also addresses https://github.com/freebsd/drm-kmod/issues/155

This firmware was previously included, but was removed due to 'module names being too long to be processed by kldxref (see: 0382c95abdcd14d14696628c61f6354553fc70a8)'. This has apparently been fixed in 13.1 + 14.0, and the firmware is required for Cezanne APU's to work on 5.10 (previously worked on 5.7 with Renoir firmware as they are closely related).

I believe the next missing piece of the puzzle is adding the relevant bits to the Makefile in the gpu-firmware-kmod port.