### PR TITLE
amdgpu: Remove mention of `sdma_6_0_4`

### DIFF
--- a/amdgpukmsfw/Makefile
+++ b/amdgpukmsfw/Makefile
@@ -52,7 +52,6 @@ _VALID_AMDGPUKMODS=	aldebaran \
 			sdma_6_0_1 \
 			sdma_6_0_2 \
 			sdma_6_0_3 \
-			sdma_6_0_4 \
 			si58 \
 			smu_13_0_0 \
 			smu_13_0_7 \


### PR DESCRIPTION
This file does not exist neither in this repository nor upstream.